### PR TITLE
Fix: disable gha autorun

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,6 +13,7 @@ runs:
   using: composite
   steps:
     - name: Run Tests
+      shell: bash
       run: |
         cd apps/${APP}
         pnpm run test:ci

--- a/.github/workflows/barefeed.yml
+++ b/.github/workflows/barefeed.yml
@@ -1,10 +1,5 @@
 name: Barefeed Workflow
-on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+on: workflow_dispatch
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
Fixes missing shell config in Test Action
Changes "barefeed" workflow to only run when triggered manually. 