### PR TITLE
fix: playwright missing browsers

### DIFF
--- a/.github/workflows/test2docs.yml
+++ b/.github/workflows/test2docs.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: "latest"
       - name: Install Dependencies
         run: pnpm install
+      - name: Install Playwright Dependencies
+        run: pnpm playwright install --with-deps
       - name: Run Tests
         uses: "./.github/actions/test"
         with:

--- a/packages/test2doc-playwright/package.json
+++ b/packages/test2doc-playwright/package.json
@@ -61,15 +61,16 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf dist && rm -rf tsconfig.tsbuildinfo",
     "build": "tsc --project tsconfig.json",
     "build:watch": "tsc --project tsconfig.json --watch",
-    "test": "vitest run && pnpm int && pnpm int:a",
-    "unit": "vitest",
+    "clean": "rm -rf dist && rm -rf tsconfig.tsbuildinfo",
+    "format": "biome format --write .",
     "int": "playwright test",
     "int:a": "playwright test --config=playwright-annotation.config.ts",
     "lint": "biome lint .",
-    "format": "biome format --write ."
+    "postinstall": "pnpm playwright install",
+    "test": "vitest run && pnpm int",
+    "unit": "vitest"
   },
   "peerDependencies": {
     "@playwright/test": "^1.54.1"


### PR DESCRIPTION
fixes `Error: browserType.launch: Executable doesn't exist` in Test2Doc GHA worfklow
fixes `Error: browserType.launch: Executable doesn't exist` when running Playwright locally after updating its version

<img width="1123" height="250" alt="Screenshot 2025-09-17 at 2 15 44 PM" src="https://github.com/user-attachments/assets/b5d70b7d-5850-474b-8f8b-33586d08cc91" />
